### PR TITLE
Fixes

### DIFF
--- a/app/models/solidus_avatax_certified/line.rb
+++ b/app/models/solidus_avatax_certified/line.rb
@@ -61,7 +61,7 @@ module SolidusAvataxCertified
         amount: shipment.discounted_amount.to_f,
         description: 'Shipping Charge',
         taxCode: shipment.shipping_method_tax_code,
-        discounted: false,
+        discounted: !shipment.promo_total.zero?,
         taxIncluded: tax_included_in_price?(shipment),
         addresses: {
           shipFrom: shipment.stock_location.to_avatax_hash,

--- a/app/models/solidus_avatax_certified/line.rb
+++ b/app/models/solidus_avatax_certified/line.rb
@@ -155,6 +155,7 @@ module SolidusAvataxCertified
     end
 
     def discounted?(line_item)
+      line_item.adjustments.any_price_matches? ||
       line_item.adjustments.promotion.eligible.any? ||
         order.adjustments.promotion.eligible.any? ||
         order.adjustments.where('amount < 0').where(source: nil).eligible.any?

--- a/app/models/solidus_avatax_certified/line.rb
+++ b/app/models/solidus_avatax_certified/line.rb
@@ -155,7 +155,9 @@ module SolidusAvataxCertified
     end
 
     def discounted?(line_item)
-      line_item.adjustments.promotion.eligible.any? || order.adjustments.promotion.eligible.any?
+      line_item.adjustments.promotion.eligible.any? ||
+        order.adjustments.promotion.eligible.any? ||
+        order.adjustments.where('amount < 0').where(source: nil).eligible.any?
     end
 
     def tax_included_in_price?(item)

--- a/config/initializers/spree.rb
+++ b/config/initializers/spree.rb
@@ -1,4 +1,3 @@
-Spree.user_class = "Spree::User"
 Spree::PermittedAttributes.user_attributes.concat([:avalara_entity_use_code_id, :exemption_number, :vat_id])
 Rails.application.config.spree.calculators.tax_rates << Spree::Calculator::AvalaraTransaction
 Spree::Config.tax_adjuster_class = SolidusAvataxCertified::OrderAdjuster

--- a/solidus_avatax_certified.gemspec
+++ b/solidus_avatax_certified.gemspec
@@ -22,7 +22,7 @@ Gem::Specification.new do |s|
   s.requirements << "none"
 
   s.add_dependency "solidus_core", [">= 2.3.0", "< 3.0.0"]
-  s.add_dependency "json", "~> 1.8"
+  s.add_dependency "json", "~> 2.0"
   s.add_dependency "avatax-ruby"
   s.add_dependency "logging", "~> 2.0"
   s.add_dependency "solidus_support"


### PR DESCRIPTION
- We don't use the `Spree::User` class, which this gem forces. We need to remove that configuration line for the app to boot.
- Version 1.8 of the `json` gem is not compatible with the version of Ruby we are using (2.5).